### PR TITLE
add drop statement to db export

### DIFF
--- a/backup_mattermost.sh
+++ b/backup_mattermost.sh
@@ -20,7 +20,7 @@ mkdir -p $gitlabBackupDir/mattermost/data
 # backup data
 cp -R $mattermostDir/* $gitlabBackupDir/mattermost/data
 # backup postgres
-su - mattermost -c "/opt/gitlab/embedded/bin/pg_dump -U gitlab_mattermost -h /var/opt/gitlab/postgresql -p 5432 mattermost_production" > $gitlabBackupDir/mattermost/mattermost_production_backup.sql
+su - mattermost -c "/opt/gitlab/embedded/bin/pg_dump -U gitlab_mattermost --clean -h /var/opt/gitlab/postgresql -p 5432 mattermost_production" > $gitlabBackupDir/mattermost/mattermost_production_backup.sql
 
 # package and cleanup
 backupfile=$(date +%s_%Y_%m_%d)_mattermost_backup.tar.gz


### PR DESCRIPTION
Using `--clean` drop db object prior restoring them

This allows for an easier import procedure, otherwise we need to manually drop and re-create the db before importing it.